### PR TITLE
Upgrade to Polymer 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
             wct -s 'default'
           fi
 before_script:
-  - npm install -g bower polylint web-component-tester
-  - bower install
-  - polylint
+  - npm install -g polymer-cli web-component-tester
+  - polymer install
+  - polymer lint
 env:
   global:
     - secure: >-

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,9 @@
 {
   "name": "platinum-https-redirect",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "authors": [
-    "The Polymer Authors"
+    "The Polymer Authors",
+    "Paul Gestwicki"
   ],
   "description": "Force a redirect to HTTPS when not on a local web server.",
   "license": "http://polymer.github.io/LICENSE.txt",
@@ -27,10 +28,11 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0"
+    "polymer": "Polymer/polymer#^2.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "^4.0.0"
+    "iron-component-page": "PolymerElements/iron-component-page#^3.0.1",
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Platinum HTTPS Redirect Demo</title>
 
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../platinum-https-redirect.html">
   </head>
 

--- a/platinum-https-redirect.html
+++ b/platinum-https-redirect.html
@@ -40,24 +40,26 @@ It can be used by just adding it to any page, e.g.
 -->
 <dom-module id="platinum-https-redirect">
   <script>
-    Polymer({
-      is: 'platinum-https-redirect',
+    class PlatinumHttpsRedirect extends Polymer.Element {
+      static get is() { return 'platinum-https-redirect'; }
 
-      _isLocalhost: function(hostname) {
+      _isLocalhost(hostname) {
         // !! coerces the logical expression to evaluate to the values true or false.
         return !!(hostname === 'localhost' ||
-                  // [::1] is the IPv6 localhost address.
-                  hostname === '[::1]' ||
-                  // 127.0.0.1/8 is considered localhost for IPv4.
-                  hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/));
-      },
+          // [::1] is the IPv6 localhost address.
+          hostname === '[::1]' ||
+          // 127.0.0.1/8 is considered localhost for IPv4.
+          hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/));
+      }
 
-      attached: function() {
-        if (window.location.protocol === 'http:' && !this._isLocalhost(window.location.hostname)) {
+      connectedCallback() {
+         if (window.location.protocol === 'http:' && !this._isLocalhost(window.location.hostname)) {
           // Redirect to https: if we're currently using http: and we're not on localhost.
           window.location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
         }
       }
-    });
+    }
+
+    window.customElements.define(PlatinumHttpsRedirect.is, PlatinumHttpsRedirect);
   </script>
 </dom-module>

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,7 @@
+{
+  "lint": {
+    "rules": [
+      "polymer-2"
+    ]
+  }
+}


### PR DESCRIPTION
The primary purpose of this pull request is to upgrade this component to Polymer 2.0. It was a fairly straightforward transformation of `platinum-https-redirect.html` from 1.0 syntax to 2.0. I updated `.travis.yml` and added a minimal `polymer.json` to use polymer-cli. I had to change the import in `demo/index.html` so that it would pass the linter. The modification to `.gitignore` simply ignores the build directory generated by `polymer build`.